### PR TITLE
feat: opt typings for createAd

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface Post {
 export interface Contributor extends UserData {
 	score: number;
 }
+
 // export interface CommentAuthor {
 // 	discriminator: string;
 // 	id: string;
@@ -171,6 +172,12 @@ export interface Announcement {
 	_id: number;
 	content: string;
 	createdAt: number;
+}
+
+export interface AdOptions {
+	mediaQuery?: string;
+	renderVisibleOnly: boolean;
+	sizes: [number, number][];
 }
 
 // export interface Profile {

--- a/src/util/createAd.ts
+++ b/src/util/createAd.ts
@@ -1,6 +1,8 @@
+import { AdOptions } from "../types";
+
 export default function createAd(
 	id: string,
-	opts: any, // TODO: (Badosz) type
+	opts: AdOptions,
 	device: "desktop" | "mobile"
 ) {
 	if (device === "desktop") {
@@ -16,7 +18,6 @@ export default function createAd(
 			demo: process.env.NODE_ENV === "development",
 			refreshLimit: 10,
 			refreshTime: 30,
-			renderVisibleOnly: false,
 			refreshVisibleOnly: true,
 			report: {
 				enabled: true,


### PR DESCRIPTION
Add opt typings for `createAd` util, additionally remove default `renderVisibleOnly` as its required in AdOptions, and will always be overwritten. 