### PR TITLE
refactor: use robots.txt instead of api path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,10 +13,6 @@ module.exports = {
 	async rewrites() {
 		return [
 			{
-				source: "/robots.txt",
-				destination: "/api/robots",
-			},
-			{
 				source: "/source",
 				destination: "/api/source",
 			},

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /*
+
+Disallow: /api/*
+Disallow: /_next/*

--- a/src/pages/api/robots/index.ts
+++ b/src/pages/api/robots/index.ts
@@ -1,7 +1,0 @@
-import { NextApiRequest, NextApiResponse } from "next";
-
-const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-	return res.status(200).send(`User-agent: *\n` + `Disallow:`);
-};
-
-export default handler;


### PR DESCRIPTION
In older versions of Next.js, it was required that you create a route for the robots.txt, but this is no longer the case. Removed redirect and api route, and disallow crawling of `api` and `_next` paths.